### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "torq/custompricing",
     "description": "torq/custompricing",
     "type": "shopware-platform-plugin",
-    "version": "0.3.2",
     "license": "MIT",
     "require": {
         "shopware/core": "^6.6.0",


### PR DESCRIPTION
This will allow Packagist to run off GitHub releases/tags

Once merged I will release as v1.1.0