### PR TITLE
Apply force-recalculate toggle on order placement route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "torq/custompricing",
     "description": "torq/custompricing",
     "type": "shopware-platform-plugin",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "license": "MIT",
     "require": {
         "shopware/core": "^6.7.0",

--- a/src/Subscriber/CacheControlSubscriber.php
+++ b/src/Subscriber/CacheControlSubscriber.php
@@ -28,7 +28,8 @@ class CacheControlSubscriber implements EventSubscriberInterface
         match($route) {
             'frontend.cart.offcanvas' => $this->cacheControlCheck(ConfigConstants::FORCE_OFF_CANVAS_RECALCULATE),
             'frontend.checkout.cart.page' => $this->cacheControlCheck(ConfigConstants::FORCE_CART_PREVIEW_RECALCULATE),
-            'frontend.checkout.confirm.page' => $this->cacheControlCheck(ConfigConstants::FORCE_CHECKOUT_CONFIRM_RECALCULATE),
+            'frontend.checkout.confirm.page',
+            'frontend.checkout.finish.order' => $this->cacheControlCheck(ConfigConstants::FORCE_CHECKOUT_CONFIRM_RECALCULATE),
             default => null
         };
     }


### PR DESCRIPTION
Clicking "Submit Order" shows the "products or prices may have changed" banner and blocks the order.

We traced it to how our custom pricing interacts with Shopware cart hash validation:

- when the customer lands on the confirm page, Shopware calculates a cart hash based on the current line item prices. 
- when they click "Submit Order" `frontend.checkout.finish.order`, Shopware recalculates the cart and compares the new hash to the previous one. If prices differ, it rejects the order with `CHECKOUT__CART_HASH_MISMATCH`.

The problem is in our [`CacheControlSubscriber`](https://github.com/TorqIT/shopware-custom-pricing/blob/fix/order-placement-recalc/src/Subscriber/CacheControlSubscriber.php#L23-L35). It listens to `KernelEvents::CONTROLLER` and on certain routes forces the custom pricing API to bypass its cache and fetch fresh prices. The confirm page (`frontend.checkout.confirm.page`) was covered by the `forceCheckoutConfirmRecalculate` toggle (enabled in `system_config`), but the order placement route (`frontend.checkout.finish.order`) was not. So:

- Confirm page: `forceApiCall = true` - [`ProductRecalculationProcessor`](https://github.com/TorqIT/shopware-custom-pricing/blob/fix/order-placement-recalc/src/Service/ProductRecalculationProcessor.php#L27-L30) marks all product line items as modified -> `ProductCartProcessor` refetches from gateway -> fresh API prices
- Place order: `forceApiCall = false` - no forced refetch -> cached prices (potentially stale) - different cart hash - mismatch

Adding `frontend.checkout.finish.order` to the [same match arm](https://github.com/TorqIT/shopware-custom-pricing/blob/fix/order-placement-recalc/src/Subscriber/CacheControlSubscriber.php#L31-L32) as `frontend.checkout.confirm.page` makes both steps use the same pricing source: fresh prices on confirm, fresh prices on submit, hashes match.