### PR TITLE
Fix/custom price upsert race

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "torq/custompricing",
     "description": "torq/custompricing",
     "type": "shopware-platform-plugin",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "license": "MIT",
     "require": {
         "shopware/core": "^6.7.0",

--- a/src/Service/CustomPriceCollectorDecorator.php
+++ b/src/Service/CustomPriceCollectorDecorator.php
@@ -4,6 +4,7 @@ namespace Torq\Shopware\CustomPricing\Service;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Shopware\Commercial\CustomPricing\Domain\CustomPriceCollector;
 use Shopware\Commercial\CustomPricing\Entity\CustomPrice\CustomPriceDefinition;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -146,6 +147,9 @@ class CustomPriceCollectorDecorator extends CustomPriceCollector
             
         }
 
-        $this->customPriceRepository->upsert($payload, \Shopware\Core\Framework\Context::createDefaultContext());
+        try {
+            $this->customPriceRepository->upsert($payload, \Shopware\Core\Framework\Context::createDefaultContext());
+        } catch (UniqueConstraintViolationException) {
+        }
     }
 }


### PR DESCRIPTION
Parallel storefront requests on the same PDP (the main page render plus the pricing and cross-sell AJAX endpoints) end up computing the same deterministic md5(customerId.productId) primary key and race on the INSERT inside customPriceRepository->upsert. The losing request currently causes the entire controller to fail with a UniqueConstraintViolationException.

Since the colliding row carries identical data, swallowing the violation preserves the intended idempotent upsert semantics without losing any prices.